### PR TITLE
Let ddev manage config by default

### DIFF
--- a/config.storybook.yaml
+++ b/config.storybook.yaml
@@ -1,3 +1,4 @@
+#ddev-generated
 web_extra_exposed_ports:
   - name: storybook
     container_port: 6006


### PR DESCRIPTION
Adding this flag indicates the file is managed by ddev, which I think is a good default behavior. Some benefits:
- indicates to users this is something created by a third-party (especially helpful when working on a team)
- ddev can auto-update the config when users update to newer versions
- ddev can clean up the config if users remove the add-on

Thanks for putting this add-on together!