### PR TITLE
simplify launch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The addon assumes the developer is correctly installed and configured Storybook 
 ddev get tyler36/ddev-storybook
 ddev restart
 ```
+2. Install storybook if you haven't already. See the [Storybook get started page](https://storybook.js.org/docs/get-started/install) for instructions. E.g.
+```shell
+ddev exec npx storybook@latest init
+```
 
 ## Usage
 

--- a/commands/host/storybook
+++ b/commands/host/storybook
@@ -21,22 +21,7 @@ startStorybookServer () {
 
 # Open storybook in prefered browser. This assumes the server is running
 launch () {
-  FULLURL="${DDEV_PRIMARY_URL}:6006"
-  case $OSTYPE in
-    linux-gnu)
-      if [[ ! -z "${GITPOD_INSTANCE_ID}" ]]; then
-        gp preview ${FULLURL}
-      else
-        xdg-open ${FULLURL}
-      fi
-      ;;
-    "darwin"*)
-      open ${FULLURL}
-      ;;
-    "win*"* | "msys"*)
-      start ${FULLURL}
-      ;;
-    esac
+  ddev launch :6006
 }
 
 

--- a/config.storybook.yaml
+++ b/config.storybook.yaml
@@ -1,3 +1,4 @@
+#ddev-generated
 web_extra_exposed_ports:
   - name: storybook
     container_port: 6006


### PR DESCRIPTION
This PR refactors the launch command.

This removes all the boilerplate browser code. Instead it launch Storybook on the default Storybook port.

Fixes #3