### PR TITLE
add missing `ddev-generated`

### DIFF
--- a/config.storybook.yaml
+++ b/config.storybook.yaml
@@ -1,3 +1,4 @@
+# #ddev-generated
 web_extra_exposed_ports:
   - name: storybook
     container_port: 6006


### PR DESCRIPTION
This PR add the missing "ddev-generated" comment. 

Without this, DDEV will NOT manage file when developers update addon.