### PR TITLE
simplify launch command

### DIFF
--- a/commands/host/storybook
+++ b/commands/host/storybook
@@ -21,22 +21,7 @@ startStorybookServer () {
 
 # Open storybook in prefered browser. This assumes the server is running
 launch () {
-  FULLURL="${DDEV_PRIMARY_URL}:6006"
-  case $OSTYPE in
-    linux-gnu)
-      if [[ ! -z "${GITPOD_INSTANCE_ID}" ]]; then
-        gp preview ${FULLURL}
-      else
-        xdg-open ${FULLURL}
-      fi
-      ;;
-    "darwin"*)
-      open ${FULLURL}
-      ;;
-    "win*"* | "msys"*)
-      start ${FULLURL}
-      ;;
-    esac
+  ddev launch :6006
 }
 
 


### PR DESCRIPTION
This PR refactors the launch command.

This removes all the boilerplate browser code. Instead it launch Storybook on the default Storybook port.

Fixes #3