### PR TITLE
Runs Without `ddev` 

### DIFF
--- a/commands/host/storybook
+++ b/commands/host/storybook
@@ -8,11 +8,11 @@
 # Define and execute command to start Storybook server
 startStorybookServer () {
   # Command used to start storybook server
-  command="ddev npm run storybook"
+  command="npm run storybook"
 
   # If 'yarn.lock' exists, we'll assume dev wants to use yarn package manager.
   if test -f ./yarn.lock; then
-    command="ddev yarn storybook"
+    command="yarn storybook"
   fi
 
   $command;


### PR DESCRIPTION
The storybook run commands work better for me without the `ddev` preface in the storybook command.

It is possible I am missing the point of the add on, or misunderstanding the purpose of the thing entirely.
