### PR TITLE
🛠️  fix: prevent storybook from automatically opening

### DIFF
--- a/commands/host/storybook
+++ b/commands/host/storybook
@@ -8,11 +8,11 @@
 # Define and execute command to start Storybook server
 startStorybookServer () {
   # Command used to start storybook server
-  command="ddev npm run storybook"
+  command="ddev npm run storybook -- --no-open"
 
   # If 'yarn.lock' exists, we'll assume dev wants to use yarn package manager.
   if test -f ./yarn.lock; then
-    command="ddev yarn storybook"
+    command="ddev yarn storybook -- --no-open"
   fi
 
   $command;


### PR DESCRIPTION
This PR update the custom storybook server command.
Specifically, it prevents the storybook from opening its page when the server starts.

Fixes #12

See https://github.com/storybookjs/storybook/issues/28772

## Alternative

Originally, this PR update the docs to instruct developers to add the `--no-open` argument to `package.json`.  This PR takes the hands-off approach and does not require developers to do anything.

Open to discussion on wether that is a better approach or not.

Tested with Storybook `8.0.8` which worked without and with this PR, so no harm to older version. 

Did NOT test with Storybook 7.




