### PR TITLE
Use `ddev add-on` command

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -27,8 +27,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
   health_checks
 }
@@ -36,8 +36,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get tyler36/ddev-storybook with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get tyler36/ddev-storybook
+  echo "# ddev add-on get tyler36/ddev-storybook with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get tyler36/ddev-storybook
   ddev restart >/dev/null
   health_checks
 }


### PR DESCRIPTION
This PR updates the tests to use the `ddev add-on` command.

`ddev get` was deprecated in `v1.23.5`.